### PR TITLE
Initial composer support.

### DIFF
--- a/salt/roots/devutils/php/composer.sls
+++ b/salt/roots/devutils/php/composer.sls
@@ -1,0 +1,14 @@
+# taken from Salt's docs
+get-composer:
+  cmd.run:
+    - name: 'CURL=`which curl`; $CURL -sS https://getcomposer.org/installer | php'
+    - unless: test -f /usr/local/bin/composer
+    - cwd: /root/
+    - shell: /bin/bash
+
+install-composer:
+  cmd.wait:
+    - name: mv /root/composer.phar /usr/local/bin/composer
+    - cwd: /root/
+    - watch:
+      - cmd: get-composer


### PR DESCRIPTION
Needs:
- [ ] - Add to `$PATH`.
- [ ] - Config data to enable in the `php` section.
- [ ] - List of composer.json's to auto-install.
